### PR TITLE
fix login form selection

### DIFF
--- a/dkb.py
+++ b/dkb.py
@@ -95,7 +95,7 @@ class DkbScraper(object):
         br.open(self.BASEURL + '?$javascript=disabled')
 
         # select login form:
-        br.form = list(br.forms())[0]
+        br.form = list(br.forms())[1]
 
         br.set_all_readonly(False)
         br.form["j_username"] = userid


### PR DESCRIPTION
DKB made small changes to their login site and the first login form
selected with

    list(br.forms())[0]

is the search field. Change to

    list(br.forms())[1]

to get the login form.