### PR TITLE
Fake user-agent to get past cloudflare

### DIFF
--- a/dkb.py
+++ b/dkb.py
@@ -118,6 +118,7 @@ class DkbScraper(object):
 
         # we are not a spider, so let's ignore robots.txt...
         br.set_handle_robots(False)
+        br.addheaders = [('User-Agent','Mozilla/5.0 (X11; Linux x86_64; rv:76.0) Gecko/20100101 Firefox/76.0')]
 
         # Although we have to handle a meta refresh, we disable it here
         # since mechanize seems to be buggy and will be stuck in a
@@ -134,10 +135,10 @@ class DkbScraper(object):
         br.form["j_password"] = pin
         br.form["jsEnabled"] = "false"
         br.form["browserName"] = "Firefox"
-        br.form["browserVersion"] = "40"
+        br.form["browserVersion"] = "76.0"
         br.form["screenWidth"] = "1000"
         br.form["screenHeight"] = "800"
-        br.form["osName"] = "Windows"
+        br.form["osName"] = "UNIX"
         response = br.submit()
         if ("Wechseln Sie in die <strong>DKB-Banking-App</strong> und best" in response.read() ):
             logger.debug("DKB-Banking-App detected")


### PR DESCRIPTION
Some time since 2020-03 and today DKB seems to have introduced some cloudflare redirection which results in

```
Starting login as user XXX...
Traceback (most recent call last):
  File "./dkb.py", line 568, in <module>
    fetcher.login(args.userid, pin)
  File "./dkb.py", line 127, in login
    br.open(self.BASEURL + '?$javascript=disabled')
  File "./dkb.py", line 47, in open
    return self._intercept_call('open', *args, **kwargs)
  File "./dkb.py", line 56, in _intercept_call
    ret = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/mechanize/_mechanize.py", line 257, in open
    return self._mech_open(url_or_request, data, timeout=timeout)
  File "/usr/lib/python2.7/site-packages/mechanize/_mechanize.py", line 313, in _mech_open
    raise response
mechanize._response.httperror_seek_wrapper: HTTP Error 403: Forbidden
```

Spoofing the  user-agent is enough to get past that.
